### PR TITLE
Use exactly matching tags for triq dependencies

### DIFF
--- a/rebar-test.config
+++ b/rebar-test.config
@@ -1,4 +1,4 @@
 {cover_enabled, true}.
 {deps, [
-         {triq, "", {git, "https://github.com/apache/couchdb-triq", {tag, "v1.2.0"}}}
+         {triq, ".*", {git, "https://github.com/apache/couchdb-triq.git", {tag, "v1.2.0"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {cover_enabled, true}.
 
 {deps, [
-         {triq, "", {git, "https://github.com/apache/couchdb-triq", {tag, "v1.2.0"}}}
+         {triq, ".*", {git, "https://github.com/apache/couchdb-triq.git", {tag, "v1.2.0"}}}
        ]}.
 
 {port_specs, [


### PR DESCRIPTION
Otherwise rebar thinks there is a conflict:

```
ERROR: Conflicting dependencies for triq: [{"From: hyper",
                                            {[],
                                             {git,
                                              "https://github.com/apache/couchdb-triq",
                                              {tag,"v1.2.0"}}}},
                                           {"From: asf2",
                                            {".*",
                                             {git,
                                              "https://github.com/apache/couchdb-triq.git",
                                              {tag,"v1.2.0"}}}}]
```