### PR TITLE
Fix hyper build for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,9 @@ erl_crash.dump
 *.so
 *.o
 *.d
+*.dll
+*.exp
+*.lib
+*.pdb
+*.swp
 .rebar

--- a/c_src/hyper_carray.c
+++ b/c_src/hyper_carray.c
@@ -55,7 +55,11 @@ struct hyper_carray {
 	uint8_t *items;
 };
 
+#ifdef _WIN32
+typedef struct hyper_carray *carray_ptr;
+#else
 typedef struct hyper_carray *restrict carray_ptr;
+#endif
 
 #define HYPER_CARRAY_SIZE sizeof(struct hyper_carray)
 
@@ -84,16 +88,22 @@ static void carray_alloc(unsigned int precision, carray_ptr * arr)
 	memset(*arr, 0, header_size);
 	(*arr)->precision = precision;
 	(*arr)->size = nitems;
-	(*arr)->items = res + header_size;
+	(*arr)->items = (uint8_t *) res + header_size;
 }
 
 /*
  * Given an hyper_carray and a valid index, set the value at that index to
  * max(current value, given value).
  */
+#ifdef _WIN32
+static void carray_merge_item(carray_ptr arr,
+				     unsigned int index,
+				     unsigned int value)
+#else
 static inline void carray_merge_item(carray_ptr arr,
 				     unsigned int index,
 				     unsigned int value)
+#endif
 {
 	uint8_t *item = arr->items + index;
 	*item = (value > *item) ? value : *item;

--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
              ]}.
 
 {port_env, [
-            {"CC", "cc"},
-            {"CFLAGS", "$CFLAGS -std=c99 -Wall -Werror -O3"}
+            {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
+                "CFLAGS", "$CFLAGS -std=c99 -Wall -Werror -O3"},
+            {"win32", "CXXFLAGS", "$CXXFLAGS /O2 /DNDEBUG"}
            ]}.


### PR DESCRIPTION
This PR works around missing C99 features for the Windows build environment, as well as necessarily fixes an attempt at pointer arithmetic with `void *`.