### PR TITLE
Remove runtime triq dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,5 @@
 {cover_enabled, true}.
 
-{deps, [
-         {triq, ".*", {git, "https://github.com/apache/couchdb-triq.git", {tag, "v1.2.0"}}}
-       ]}.
-
 {port_specs, [
               {"priv/hyper_carray.so", ["c_src/hyper_carray.c"]}
              ]}.


### PR DESCRIPTION
This was the only place that was bringing in triq even for CouchDB's own tests,
we never added it to the main list of deps. Trying to switch to PropEr so
seeing if we can remove it and make a new release without it.